### PR TITLE
Changed tsconfig.json so that VS Code recognizes jest types

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -2,4 +2,5 @@ export default {
     preset: 'ts-jest',
     testEnvironment: 'node',
     // Add other options here, like test match patterns, coverage, etc.
+    testMatch: ['**/*.test.ts'], // Or your specific test file pattern
 };

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -32,7 +32,7 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["jest"],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["jest", "node"],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
@@ -106,5 +106,5 @@
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*/__tests__/*"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
The test files are no longer excluded in tsconfig.json. Meaning they compile. jest.config.ts only runs the typescript version of the files. Ideally, the tests would not be compiled to JS in the first place, but I'm not sure how to do that and still have VS Code recognize the jest types